### PR TITLE
Feat: Client functions to get transactions at an address / payment credential...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Revision history for `maestro-sdk`
 
+## [1.6.0](https://github.com/maestro-org/haskell-sdk/compare/v1.5.0..v1.6.0) -- 2024-04-09
+
+Added:
+
+* GET `/addresses/:address/transactions`
+* `asset` query parameter to GET `/addresses/cred/:credential/utxos`
+* POST `/addresses/cred/utxos`
+* GET `/addresses/cred/:credential/transactions`
+* GET `/assets/:asset`
+* `from`, `to`, `limit` query parameters to GET `/markets/dexs/ohlc/:dex/:pair`
+* provision to prevent api-key from being leaked in error messages
+* provision to handle Maestro error bodies which are not enclosed in double quotes. Earlier behaviour was to expect message such as `"Failed to deserialise"` and not `Failed to deserialise`.
+* `FromHttpApiData`, `ToHttpApiData` instance for `SlotNo`
+* `Eq`, `Ord`, `Enum`, `Bounded`, `ToJSON`, `FromHttpApiData` instance for `Order`
+* `Enum`, `Bounded`, `FromHttpApiData` instance for `Dex`
+* `Data`, `Typeable`, `Enum`, `Bounded`, `FromHttpApiData` instance for `Resolution` and also refactored it's `Show` instance.
+
 ## [1.5.0](https://github.com/maestro-org/haskell-sdk/compare/v1.4.0..v1.5.0) -- 2024-01-02
 
 * Added support GeniusYield DEX to market defi endpoints in [#45](https://github.com/maestro-org/haskell-sdk/pull/45).

--- a/maestro-sdk.cabal
+++ b/maestro-sdk.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               maestro-sdk
-version:            1.5.0
+version:            1.6.0
 synopsis:           Maestro Blockchain Indexer SDK
 description:
   Maestro provides blockchain indexers, APIs and event management systems for the Cardano blockchain.

--- a/maestro-sdk.cabal
+++ b/maestro-sdk.cabal
@@ -49,6 +49,7 @@ library
     Maestro.API.V1
     Maestro.API.V1.Accounts
     Maestro.API.V1.Addresses
+    Maestro.API.V1.Assets
     Maestro.API.V1.Blocks
     Maestro.API.V1.Datum
     Maestro.API.V1.DefiMarkets
@@ -61,6 +62,7 @@ library
     Maestro.Client.V1
     Maestro.Client.V1.Accounts
     Maestro.Client.V1.Addresses
+    Maestro.Client.V1.Assets
     Maestro.Client.V1.Blocks
     Maestro.Client.V1.Core
     Maestro.Client.V1.Core.Pagination
@@ -74,6 +76,7 @@ library
     Maestro.Types.V1
     Maestro.Types.V1.Accounts
     Maestro.Types.V1.Addresses
+    Maestro.Types.V1.Assets
     Maestro.Types.V1.Blocks
     Maestro.Types.V1.Common
     Maestro.Types.V1.Common.Pagination

--- a/maestro-sdk.cabal
+++ b/maestro-sdk.cabal
@@ -2,7 +2,9 @@ cabal-version:      3.0
 name:               maestro-sdk
 version:            1.5.0
 synopsis:           Maestro Blockchain Indexer SDK
-description:        Maestro provides blockchain indexers, APIs and event management systems for the Cardano blockchain.
+description:
+  Maestro provides blockchain indexers, APIs and event management systems for the Cardano blockchain.
+
 license:            Apache-2.0
 license-file:       LICENSE
 author:             support@gomaestro.org
@@ -12,118 +14,112 @@ build-type:         Simple
 category:           Blockchain, Cardano, SDK, API, REST
 extra-doc-files:    CHANGELOG.md
 extra-source-files: README.md
-tested-with:        GHC == { 8.10.7, 9.2.8, 9.6.2 }
+tested-with:        GHC ==8.10.7 || ==9.2.8 || ==9.6.2
 
 source-repository head
   type:     git
   location: https://github.com/maestro-org/haskell-sdk
 
 common common
-    ghc-options: -Wall
-    default-extensions:
-      GADTs
-      DataKinds
-      DeriveGeneric
-      DerivingStrategies
-      DerivingVia
-      GeneralisedNewtypeDeriving
-      FlexibleInstances
-      FlexibleContexts
-      MultiParamTypeClasses
-      NumericUnderscores
-      OverloadedStrings
-      RecordWildCards
-      RoleAnnotations
-      ScopedTypeVariables
-      TemplateHaskell
-      TypeApplications
-      TypeFamilies
-      TypeOperators
-      QuasiQuotes
+  ghc-options:        -Wall
+  default-extensions:
+    DataKinds
+    DeriveGeneric
+    DerivingStrategies
+    DerivingVia
+    FlexibleContexts
+    FlexibleInstances
+    GADTs
+    GeneralisedNewtypeDeriving
+    MultiParamTypeClasses
+    NumericUnderscores
+    OverloadedStrings
+    QuasiQuotes
+    RecordWildCards
+    RoleAnnotations
+    ScopedTypeVariables
+    TemplateHaskell
+    TypeApplications
+    TypeFamilies
+    TypeOperators
 
 library
-    import:           common
-    exposed-modules:
-      Maestro.API.V1
-      Maestro.API.V1.Accounts
-      Maestro.API.V1.Addresses
-      Maestro.API.V1.Blocks
-      Maestro.API.V1.Datum
-      Maestro.API.V1.DefiMarkets
-      Maestro.API.V1.General
-      Maestro.API.V1.Pools
-      Maestro.API.V1.Transactions
-      Maestro.API.V1.TxManager
+  import:           common
+  exposed-modules:
+    Maestro.API.V1
+    Maestro.API.V1.Accounts
+    Maestro.API.V1.Addresses
+    Maestro.API.V1.Blocks
+    Maestro.API.V1.Datum
+    Maestro.API.V1.DefiMarkets
+    Maestro.API.V1.General
+    Maestro.API.V1.Pools
+    Maestro.API.V1.Transactions
+    Maestro.API.V1.TxManager
+    Maestro.Client.Env
+    Maestro.Client.Error
+    Maestro.Client.V1
+    Maestro.Client.V1.Accounts
+    Maestro.Client.V1.Addresses
+    Maestro.Client.V1.Blocks
+    Maestro.Client.V1.Core
+    Maestro.Client.V1.Core.Pagination
+    Maestro.Client.V1.Datum
+    Maestro.Client.V1.DefiMarkets
+    Maestro.Client.V1.General
+    Maestro.Client.V1.Pools
+    Maestro.Client.V1.Transactions
+    Maestro.Client.V1.TxManager
+    Maestro.Types.Common
+    Maestro.Types.V1
+    Maestro.Types.V1.Accounts
+    Maestro.Types.V1.Addresses
+    Maestro.Types.V1.Blocks
+    Maestro.Types.V1.Common
+    Maestro.Types.V1.Common.Pagination
+    Maestro.Types.V1.Common.Timestamped
+    Maestro.Types.V1.Datum
+    Maestro.Types.V1.DefiMarkets
+    Maestro.Types.V1.General
+    Maestro.Types.V1.Pools
+    Maestro.Types.V1.Transactions
 
-      Maestro.Client.Env
-      Maestro.Client.Error
+  build-depends:
+    , aeson                ^>=2.1
+    , base                 ^>=4.14.3.0 || ^>=4.16.4.0 || ^>=4.18.0.0
+    , bytestring           >=0.10      && <0.11       || ^>=0.11
+    , containers           ^>=0.6
+    , data-default-class   ^>=0.1
+    , deriving-aeson       ^>=0.2
+    , http-api-data        >=0.5       && <0.6        || ^>=0.6
+    , http-client          ^>=0.7
+    , http-client-tls      ^>=0.3
+    , http-types           ^>=0.12
+    , retry                ^>=0.9
+    , servant              >=0.19      && <0.20       || ^>=0.20
+    , servant-client       >=0.19      && <0.20       || ^>=0.20
+    , servant-client-core  >=0.19      && <0.20       || ^>=0.20
+    , text                 ^>=1.2      || ^>=2.0
+    , time                 ^>=1.9      || >=1.11      && <1.12       || ^>=1.12
 
-      Maestro.Client.V1
-      Maestro.Client.V1.Core
-      Maestro.Client.V1.Core.Pagination
-      Maestro.Client.V1.Accounts
-      Maestro.Client.V1.Addresses
-      Maestro.Client.V1.Blocks
-      Maestro.Client.V1.Datum
-      Maestro.Client.V1.DefiMarkets
-      Maestro.Client.V1.General
-      Maestro.Client.V1.Pools
-      Maestro.Client.V1.Transactions
-      Maestro.Client.V1.TxManager
-
-      Maestro.Types.Common
-
-      Maestro.Types.V1
-      Maestro.Types.V1.Accounts
-      Maestro.Types.V1.Addresses
-      Maestro.Types.V1.Blocks
-      Maestro.Types.V1.Datum
-      Maestro.Types.V1.DefiMarkets
-      Maestro.Types.V1.Common
-      Maestro.Types.V1.Common.Pagination
-      Maestro.Types.V1.Common.Timestamped
-      Maestro.Types.V1.General
-      Maestro.Types.V1.Pools
-      Maestro.Types.V1.Transactions
-
-    build-depends:
-      aeson ^>=2.1,
-      base ^>=4.14.3.0 || ^>=4.16.4.0 || ^>=4.18.0.0,
-      bytestring ^>=0.10 || ^>=0.11,
-      containers ^>=0.6,
-      data-default-class ^>=0.1,
-      deriving-aeson ^>=0.2,
-      http-api-data ^>=0.5 || ^>=0.6,
-      http-client ^>=0.7,
-      http-client-tls ^>=0.3,
-      http-types ^>=0.12,
-      retry ^>=0.9,
-      servant ^>=0.19 || ^>=0.20,
-      servant-client ^>=0.19 || ^>=0.20,
-      servant-client-core ^>=0.19 || ^>=0.20,
-      text ^>=1.2 || ^>=2.0,
-      time ^>=1.9 || ^>=1.11 || ^>=1.12
-
-    hs-source-dirs:   src
-    default-language: Haskell2010
+  hs-source-dirs:   src
+  default-language: Haskell2010
 
 test-suite maestro-sdk-tests
-    import:           common
-    default-language: Haskell2010
-    type:             exitcode-stdio-1.0
-    hs-source-dirs:   test
-    main-is:          Driver.hs
-    other-modules:
-        Maestro.Test.Backoff
+  import:             common
+  default-language:   Haskell2010
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     test
+  main-is:            Driver.hs
+  other-modules:      Maestro.Test.Backoff
+  build-depends:
+    , base         ^>=4.14.3.0 || ^>=4.16.4.0 || ^>=4.18.0.0
+    , containers   ^>=0.6.5.1
+    , hspec        ^>=2.11.4
+    , maestro-sdk
+    , tasty        ^>=1.4.3
+    , tasty-hspec  ^>=1.2.0.4
+    , text         ^>=1.2.4.1  || ^>=2.0.2
+    , time         ^>=1.9.3    || ^>=1.11.1.1 || ^>=1.12.2
 
-    build-depends:
-        base ^>=4.14.3.0 || ^>=4.16.4.0 || ^>=4.18.0.0,
-        maestro-sdk,
-        containers ^>=0.6.5.1,
-        hspec ^>=2.11.4,
-        tasty ^>=1.4.3,
-        tasty-hspec ^>=1.2.0.4,
-        text ^>=1.2.4.1 || ^>=2.0.2,
-        time ^>=1.9.3 || ^>=1.11.1.1 || ^>=1.12.2
-    build-tool-depends:
-        tasty-discover:tasty-discover
+  build-tool-depends: tasty-discover:tasty-discover

--- a/src/Maestro/API/V1.hs
+++ b/src/Maestro/API/V1.hs
@@ -3,6 +3,7 @@ module Maestro.API.V1 where
 import           Data.Text                   (Text)
 import           Maestro.API.V1.Accounts
 import           Maestro.API.V1.Addresses
+import           Maestro.API.V1.Assets
 import           Maestro.API.V1.Blocks
 import           Maestro.API.V1.Datum
 import           Maestro.API.V1.DefiMarkets
@@ -23,6 +24,7 @@ data MaestroApiV1 route  = MaestroApiV1
   , pools        :: route :- "pools" :> ToServantApi PoolsAPI
   , txManager    :: route :- "txmanager" :> ToServantApi TxManagerAPI
   , transactions :: route :- "transactions" :> ToServantApi TransactionsAPI
+  , assets       :: route :- "assets" :> ToServantApi AssetsAPI
   } deriving Generic
 
 newtype MaestroApiV1Auth route = MaestroApiV1Auth

--- a/src/Maestro/API/V1/Addresses.hs
+++ b/src/Maestro/API/V1/Addresses.hs
@@ -69,7 +69,7 @@ data AddressesAPI route = AddressesAPI
       :> QueryParam "with_cbor" Bool
       :> Pagination
       :> ReqBody '[JSON] [Bech32StringOf PaymentCredentialAddress]
-      :> Get '[JSON] PaginatedUtxoWithSlot
+      :> Post '[JSON] PaginatedUtxoWithSlot
 
   , paymentCredentialTxs
       :: route

--- a/src/Maestro/API/V1/Addresses.hs
+++ b/src/Maestro/API/V1/Addresses.hs
@@ -60,6 +60,16 @@ data AddressesAPI route = AddressesAPI
       :> Pagination
       :> Get '[JSON] PaginatedUtxoWithSlot
 
+  , paymentCredentialsUtxos
+      :: route
+      :- "cred"
+      :> "utxos"
+      :> QueryParam "resolve_datums" Bool
+      :> QueryParam "with_cbor" Bool
+      :> Pagination
+      :> ReqBody '[JSON] [Bech32StringOf PaymentCredentialAddress]
+      :> Get '[JSON] PaginatedUtxoWithSlot
+
   , paymentCredentialTxs
       :: route
       :- "cred"

--- a/src/Maestro/API/V1/Addresses.hs
+++ b/src/Maestro/API/V1/Addresses.hs
@@ -39,6 +39,16 @@ data AddressesAPI route = AddressesAPI
       :> Pagination
       :> Get '[JSON] PaginatedOutputReferenceObject
 
+  , addressTxs
+      :: route
+      :- Capture "address" (Bech32StringOf Address)
+      :> "transactions"
+      :> QueryParam "order" Order
+      :> QueryParam "from" SlotNo
+      :> QueryParam "to" SlotNo
+      :> Pagination
+      :> Get '[JSON] PaginatedAddressTransaction
+
   , paymentCredentialUtxos
       :: route
       :- "cred"
@@ -49,5 +59,16 @@ data AddressesAPI route = AddressesAPI
       -- TODO: Support for more query parameters.
       :> Pagination
       :> Get '[JSON] PaginatedUtxoWithSlot
+
+  , paymentCredentialTxs
+      :: route
+      :- "cred"
+      :> Capture "credential" (Bech32StringOf PaymentCredentialAddress)
+      :> "transactions"
+      :> QueryParam "order" Order
+      :> QueryParam "from" SlotNo
+      :> QueryParam "to" SlotNo
+      :> Pagination
+      :> Get '[JSON] PaginatedPaymentCredentialTransaction
 
   } deriving (Generic)

--- a/src/Maestro/API/V1/Addresses.hs
+++ b/src/Maestro/API/V1/Addresses.hs
@@ -56,6 +56,7 @@ data AddressesAPI route = AddressesAPI
       :> "utxos"
       :> QueryParam "resolve_datums" Bool
       :> QueryParam "with_cbor" Bool
+      :> QueryParam "asset" NonAdaNativeToken
       -- TODO: Support for more query parameters.
       :> Pagination
       :> Get '[JSON] PaginatedUtxoWithSlot

--- a/src/Maestro/API/V1/Assets.hs
+++ b/src/Maestro/API/V1/Assets.hs
@@ -1,0 +1,14 @@
+module Maestro.API.V1.Assets where
+
+import Maestro.Types.V1
+import Servant.API
+import Servant.API.Generic
+
+data AssetsAPI route = AssetsAPI
+  { assetInfo ::
+      route
+        :- Capture "asset" NonAdaNativeToken
+          :> Get '[JSON] TimestampedAssetInfo
+  -- ^ Native asset information.
+  }
+  deriving (Generic)

--- a/src/Maestro/API/V1/DefiMarkets.hs
+++ b/src/Maestro/API/V1/DefiMarkets.hs
@@ -1,23 +1,26 @@
 module Maestro.API.V1.DefiMarkets where
 
-import           Maestro.Types.V1
-import           Servant.API
-import           Servant.API.Generic
+import Data.Time (Day)
+import Data.Word (Word64)
+import Maestro.Types.V1
+import Servant.API
+import Servant.API.Generic
 
 data DefiMarketsAPI route = DefiMarketsAPI
-  {
-    dexOHLC
-      :: route
-      :- "ohlc"
-      :> Capture "dex" Dex
-      :> Capture "pair" (TaggedText PairOfDexTokens)
-      :> QueryParam "resolution" Resolution
-      :> QueryParam "sort" Order
-      :> Get '[JSON] [OHLCCandleInfo]
-
-  , dexPairs
-      :: route
-      :- Capture "dex" Dex
-      :> Get '[JSON] DexPairResponse
-
-  } deriving (Generic)
+  { dexOHLC ::
+      route
+        :- "ohlc"
+          :> Capture "dex" Dex
+          :> Capture "pair" (TaggedText PairOfDexTokens)
+          :> QueryParam "resolution" Resolution
+          :> QueryParam "from" Day
+          :> QueryParam "to" Day
+          :> QueryParam "limit" Word64
+          :> QueryParam "sort" Order
+          :> Get '[JSON] [OHLCCandleInfo]
+  , dexPairs ::
+      route
+        :- Capture "dex" Dex
+          :> Get '[JSON] DexPairResponse
+  }
+  deriving (Generic)

--- a/src/Maestro/Client/Error.hs
+++ b/src/Maestro/Client/Error.hs
@@ -7,9 +7,11 @@ module Maestro.Client.Error
   , fromServantClientError
   ) where
 
-import           Control.Exception       (Exception)
-import           Data.Aeson              (decode)
-import           Data.Text               (Text)
+import           Control.Exception    (Exception)
+import           Data.Aeson           (decode)
+import           Data.ByteString      (toStrict)
+import           Data.Text            (Text)
+import           Data.Text.Encoding   (decodeLatin1)
 import           Deriving.Aeson
 import           Maestro.Types.Common (LowerFirst)
 import           Network.HTTP.Types
@@ -74,4 +76,4 @@ fromServantClientError e = case e of
         Nothing               ->
           case decode body of
             Just (m :: Text) -> m
-            Nothing          -> mempty
+            Nothing          -> decodeLatin1 $ toStrict body

--- a/src/Maestro/Client/Error.hs
+++ b/src/Maestro/Client/Error.hs
@@ -10,8 +10,10 @@ module Maestro.Client.Error
 import           Control.Exception    (Exception (..), SomeException (..))
 import           Data.Aeson           (decode)
 import           Data.ByteString      (toStrict)
+import           Data.Either          (fromRight)
+import           Data.Function        ((&))
 import           Data.Text            (Text)
-import           Data.Text.Encoding   (decodeLatin1)
+import           Data.Text.Encoding   (decodeUtf8')
 import           Deriving.Aeson
 import           Maestro.Types.Common (LowerFirst)
 import qualified Network.HTTP.Client as Client
@@ -82,4 +84,4 @@ fromServantClientError e = let sce = ServantClientError e in case e of
         Nothing               ->
           case decode body of
             Just (m :: Text) -> m
-            Nothing          -> decodeLatin1 $ toStrict body
+            Nothing          -> toStrict body & decodeUtf8' & fromRight mempty

--- a/src/Maestro/Client/Error.hs
+++ b/src/Maestro/Client/Error.hs
@@ -9,14 +9,14 @@ module Maestro.Client.Error
 
 import           Control.Exception    (Exception (..), SomeException (..))
 import           Data.Aeson           (decode)
-import           Data.ByteString      (toStrict)
+import           Data.ByteString.Lazy (toStrict)
 import           Data.Either          (fromRight)
 import           Data.Function        ((&))
 import           Data.Text            (Text)
 import           Data.Text.Encoding   (decodeUtf8')
 import           Deriving.Aeson
 import           Maestro.Types.Common (LowerFirst)
-import qualified Network.HTTP.Client as Client
+import qualified Network.HTTP.Client  as Client
 import           Network.HTTP.Types
 import           Servant.Client
 

--- a/src/Maestro/Client/V1.hs
+++ b/src/Maestro/Client/V1.hs
@@ -3,6 +3,7 @@ module Maestro.Client.V1
   , module Maestro.Client.Error
   , module Maestro.Client.V1.Core
   , module Maestro.Client.V1.Addresses
+  , module Maestro.Client.V1.Assets
   , module Maestro.Client.V1.Blocks
   , module Maestro.Client.V1.Datum
   , module Maestro.Client.V1.DefiMarkets
@@ -16,6 +17,7 @@ module Maestro.Client.V1
 import           Maestro.Client.Env
 import           Maestro.Client.Error
 import           Maestro.Client.V1.Addresses
+import           Maestro.Client.V1.Assets
 import           Maestro.Client.V1.Blocks
 import           Maestro.Client.V1.Core
 import           Maestro.Client.V1.Datum

--- a/src/Maestro/Client/V1/Addresses.hs
+++ b/src/Maestro/Client/V1/Addresses.hs
@@ -5,17 +5,22 @@ module Maestro.Client.V1.Addresses (
     utxosAtMultiAddresses,
     getRefsAtAddress,
     utxosByPaymentCredential,
+    txsByAddress,
+    txsByPaymentCredential,
   ) where
 
 import           Maestro.API.V1
 import           Maestro.API.V1.Addresses
 import           Maestro.Client.Env
 import           Maestro.Client.V1.Core
-import           Maestro.Types.Common     (Address, Bech32StringOf)
-import           Maestro.Types.V1         (NonAdaNativeToken,
-                                           PaginatedOutputReferenceObject,
-                                           PaginatedUtxoWithSlot,
-                                           PaymentCredentialAddress)
+import           Maestro.Types.Common       (Address, Bech32StringOf, Order,
+                                             SlotNo)
+import           Maestro.Types.V1           (NonAdaNativeToken,
+                                             PaginatedOutputReferenceObject,
+                                             PaginatedPaymentCredentialTransaction,
+                                             PaginatedUtxoWithSlot,
+                                             PaymentCredentialAddress)
+import           Maestro.Types.V1.Addresses (PaginatedAddressTransaction)
 import           Servant.API.Generic
 import           Servant.Client
 
@@ -77,3 +82,39 @@ utxosByPaymentCredential ::
   Cursor ->
   IO PaginatedUtxoWithSlot
 utxosByPaymentCredential = paymentCredentialUtxos . addressClient
+
+-- | Returns transactions in which the specified address spent or received funds.
+--
+-- Specifically, the transactions where: the address controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
+txsByAddress ::
+  MaestroEnv 'V1 ->
+  -- | Address in bech32 format.
+  Bech32StringOf Address ->
+  -- | The order in which the results are sorted (by point in chain).
+  Maybe Order ->
+  -- | Return only transactions minted on or after a specific slot.
+  Maybe SlotNo ->
+  -- | Return only transactions minted on or before a specific slot.
+  Maybe SlotNo ->
+  -- | The pagination attributes.
+  Cursor ->
+  IO PaginatedAddressTransaction
+txsByAddress = addressTxs . addressClient
+
+-- | Returns transactions in which the specified payment credential spent or received funds, or was a required signer.
+--
+-- Specifically, "spent or received funds" meaning: the payment credential was used in an address which controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
+txsByPaymentCredential ::
+  MaestroEnv 'V1 ->
+  -- | Payment credential in bech32 format.
+  Bech32StringOf PaymentCredentialAddress ->
+  -- | The order in which the results are sorted (by point in chain).
+  Maybe Order ->
+  -- | Return only transactions minted on or after a specific slot.
+  Maybe SlotNo ->
+  -- | Return only transactions minted on or before a specific slot.
+  Maybe SlotNo ->
+  -- | The pagination attributes.
+  Cursor ->
+  IO PaginatedPaymentCredentialTransaction
+txsByPaymentCredential = paymentCredentialTxs . addressClient

--- a/src/Maestro/Client/V1/Addresses.hs
+++ b/src/Maestro/Client/V1/Addresses.hs
@@ -79,6 +79,8 @@ utxosByPaymentCredential ::
   Maybe Bool ->
   -- | Query Param to include the CBOR encodings of the transaction outputs in the response.
   Maybe Bool ->
+  -- | Query Param to return for only those UTxOs which contain this given asset.
+  Maybe NonAdaNativeToken ->
   -- | The pagination attributes.
   Cursor ->
   IO PaginatedUtxoWithSlot

--- a/src/Maestro/Client/V1/Addresses.hs
+++ b/src/Maestro/Client/V1/Addresses.hs
@@ -5,6 +5,7 @@ module Maestro.Client.V1.Addresses (
     utxosAtMultiAddresses,
     getRefsAtAddress,
     utxosByPaymentCredential,
+    utxosByMultiPaymentCredentials,
     txsByAddress,
     txsByPaymentCredential,
   ) where
@@ -82,6 +83,21 @@ utxosByPaymentCredential ::
   Cursor ->
   IO PaginatedUtxoWithSlot
 utxosByPaymentCredential = paymentCredentialUtxos . addressClient
+
+-- | Returns list of utxos for multiple payment credentials.
+utxosByMultiPaymentCredentials ::
+  -- | The Maestro Environment.
+  MaestroEnv 'V1 ->
+  -- | Query param to include the corresponding datums for datum hashes.
+  Maybe Bool ->
+  -- | Query Param to include the CBOR encodings of the transaction outputs in the response.
+  Maybe Bool ->
+  -- | The pagination attributes.
+  Cursor ->
+  -- | List of payment credential in bech32 format to fetch utxo from.
+  [Bech32StringOf PaymentCredentialAddress] ->
+  IO PaginatedUtxoWithSlot
+utxosByMultiPaymentCredentials = paymentCredentialsUtxos . addressClient
 
 -- | Returns transactions in which the specified address spent or received funds.
 --

--- a/src/Maestro/Client/V1/Assets.hs
+++ b/src/Maestro/Client/V1/Assets.hs
@@ -1,0 +1,24 @@
+-- | Module to query for /\"Assets\"/ category of endpoints defined at [docs.gomaestro.org](https://docs.gomaestro.org/Indexer-API/Assets/asset-addresses).
+module Maestro.Client.V1.Assets (
+  assetInfo,
+) where
+
+import Maestro.API.V1 (assets)
+import qualified Maestro.API.V1.Assets as Mapi
+import Maestro.Client.Env
+import Maestro.Client.V1.Core
+import Maestro.Types.V1
+import Servant.API.Generic
+import Servant.Client
+
+txClient :: MaestroEnv 'V1 -> Mapi.AssetsAPI (AsClientT IO)
+txClient = fromServant . assets . apiV1Client
+
+-- | Native asset information.
+assetInfo ::
+  -- | The Maestro Environment.
+  MaestroEnv 'V1 ->
+  -- | `NonAdaNativeToken` to query.
+  NonAdaNativeToken ->
+  IO TimestampedAssetInfo
+assetInfo = Mapi.assetInfo . txClient

--- a/src/Maestro/Client/V1/DefiMarkets.hs
+++ b/src/Maestro/Client/V1/DefiMarkets.hs
@@ -1,18 +1,19 @@
 -- | Module to query for /"DeFi Markets"/ category of endpoints defined at [docs.gomaestro.org](https://docs.gomaestro.org/category/defi-market-api).
-
 module Maestro.Client.V1.DefiMarkets (
-    pricesFromDex,
-    pairsFromDex
-  ) where
+  pricesFromDex,
+  pairsFromDex,
+) where
 
-import           Maestro.API.V1
-import           Maestro.API.V1.DefiMarkets
-import           Maestro.Client.Env
-import           Maestro.Client.V1.Core
-import           Maestro.Types.Common     (Order)
-import           Maestro.Types.V1         (Resolution, Dex, TaggedText, PairOfDexTokens,DexPairResponse, OHLCCandleInfo)
-import           Servant.API.Generic
-import           Servant.Client
+import Data.Time (Day)
+import Data.Word (Word64)
+import Maestro.API.V1
+import Maestro.API.V1.DefiMarkets
+import Maestro.Client.Env
+import Maestro.Client.V1.Core
+import Maestro.Types.Common (Order)
+import Maestro.Types.V1 (Dex, DexPairResponse, OHLCCandleInfo, PairOfDexTokens, Resolution, TaggedText)
+import Servant.API.Generic
+import Servant.Client
 
 defiMarketsClient :: MaestroEnv 'V1 -> DefiMarketsAPI (AsClientT IO)
 defiMarketsClient = fromServant . defiMarkets . apiV1Client
@@ -20,9 +21,19 @@ defiMarketsClient = fromServant . defiMarkets . apiV1Client
 -- | Returns a list of OHLC formatted candles from the desired dex
 pricesFromDex ::
   MaestroEnv 'V1 ->
+  -- | Dex.
   Dex ->
+  -- | Pair.
   TaggedText PairOfDexTokens ->
+  -- | Resolution.
   Maybe Resolution ->
+  -- | From day.
+  Maybe Day ->
+  -- | To day.
+  Maybe Day ->
+  -- | Limit. Default value is @5000@.
+  Maybe Word64 ->
+  -- | Order.
   Maybe Order ->
   IO [OHLCCandleInfo]
 pricesFromDex = dexOHLC . defiMarketsClient

--- a/src/Maestro/Types/Common.hs
+++ b/src/Maestro/Types/Common.hs
@@ -90,7 +90,7 @@ newtype AbsoluteSlot = AbsoluteSlot {unAbsoluteSlot :: Natural}
 -- | The 0-based index for the Ourboros time slot.
 newtype SlotNo = SlotNo {unSlotNo :: Word64}
   deriving stock (Eq, Ord, Show, Generic)
-  deriving newtype (Num, Bounded, Enum, Real, Integral, FromJSON, ToJSON)
+  deriving newtype (Num, Bounded, Enum, Real, Integral, FromJSON, ToJSON, FromHttpApiData, ToHttpApiData)
 
 -- | Block Height
 newtype BlockHeight = BlockHeight {unBlockHeight :: Natural}

--- a/src/Maestro/Types/Common.hs
+++ b/src/Maestro/Types/Common.hs
@@ -169,11 +169,15 @@ data Script = Script
 
 -- Datatype to represent for /"order"/ query parameter in some of the API requests.
 data Order = Ascending | Descending
+  deriving stock (Eq, Ord, Enum, Bounded)
 
 -- Don't change @Show@ instance blindly, as `ToHttpApiData` instance is making use of it.
 instance Show Order where
   show Ascending  = "asc"
   show Descending = "desc"
+
+instance ToJSON Order where
+  toJSON = Aeson.String . T.pack . show
 
 instance ToHttpApiData Order where
   toQueryParam order = T.pack $ show order

--- a/src/Maestro/Types/Common.hs
+++ b/src/Maestro/Types/Common.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 -- | Common (shared) types between different versions of Maestro-API.
 
 module Maestro.Types.Common
@@ -176,6 +177,12 @@ instance Show Order where
 
 instance ToHttpApiData Order where
   toQueryParam order = T.pack $ show order
+
+instance FromHttpApiData Order where
+  parseQueryParam = \case
+    "asc"  -> Right Ascending
+    "desc" -> Right Descending
+    _      -> Left "Invalid Order"
 
 instance Default Order where
   def = Ascending

--- a/src/Maestro/Types/V1.hs
+++ b/src/Maestro/Types/V1.hs
@@ -3,6 +3,7 @@
 module Maestro.Types.V1
   ( module Maestro.Types.V1.Accounts
   , module Maestro.Types.V1.Addresses
+  , module Maestro.Types.V1.Assets
   , module Maestro.Types.V1.Blocks
   , module Maestro.Types.V1.Common
   , module Maestro.Types.V1.Datum
@@ -14,6 +15,7 @@ module Maestro.Types.V1
 
 import           Maestro.Types.V1.Accounts
 import           Maestro.Types.V1.Addresses
+import           Maestro.Types.V1.Assets
 import           Maestro.Types.V1.Blocks
 import           Maestro.Types.V1.Common
 import           Maestro.Types.V1.Datum

--- a/src/Maestro/Types/V1/Addresses.hs
+++ b/src/Maestro/Types/V1/Addresses.hs
@@ -12,6 +12,10 @@ module Maestro.Types.V1.Addresses (
     AddressInfo (..),
     OutputReferenceObject (..),
     PaginatedOutputReferenceObject (..),
+    AddressTransaction (..),
+    PaginatedAddressTransaction (..),
+    PaymentCredentialTransaction (..),
+    PaginatedPaymentCredentialTransaction (..),
   ) where
 
 import           Deriving.Aeson
@@ -131,3 +135,77 @@ instance IsTimestamped PaginatedOutputReferenceObject where
 
 instance HasCursor PaginatedOutputReferenceObject where
   getNextCursor = paginatedOutputReferenceObjectNextCursor
+
+-- | Transaction which involved a specific address.
+data AddressTransaction = AddressTransaction
+  { addressTransactionTxHash :: !TxHash
+  -- ^ Transaction hash.
+  , addressTransactionSlot   :: !SlotNo
+  -- ^ Absolute slot of the block which contains the transaction.
+  , addressTransactionInput  :: !Bool
+  -- ^ Address controlled at least one of the consumed UTxOs.
+  , addressTransactionOutput :: !Bool
+  -- ^ Address controlled at least one of the produced UTxOs.
+  }
+  deriving stock (Show, Eq, Generic)
+  deriving (FromJSON, ToJSON)
+  via CustomJSON '[FieldLabelModifier '[StripPrefix "addressTransaction", CamelToSnake]] AddressTransaction
+
+-- | A paginated response over `AddressTransaction`.
+data PaginatedAddressTransaction = PaginatedAddressTransaction
+  { paginatedAddressTransactionData        :: ![AddressTransaction]
+  -- ^ See `AddressTransaction`.
+  , paginatedAddressTransactionLastUpdated :: !LastUpdated
+  -- ^ See `LastUpdated`.
+  , paginatedAddressTransactionNextCursor  :: !(Maybe NextCursor)
+  -- ^ See `NextCursor`.
+  }
+  deriving stock (Show, Eq, Generic)
+  deriving (FromJSON, ToJSON)
+  via CustomJSON '[FieldLabelModifier '[StripPrefix "paginatedAddressTransaction", CamelToSnake]] PaginatedAddressTransaction
+
+instance IsTimestamped PaginatedAddressTransaction where
+  type TimestampedData PaginatedAddressTransaction = [AddressTransaction]
+  getTimestampedData = paginatedAddressTransactionData
+  getTimestamp = paginatedAddressTransactionLastUpdated
+
+instance HasCursor PaginatedAddressTransaction where
+  getNextCursor = paginatedAddressTransactionNextCursor
+
+-- | Transaction which involved a specific payment credential.
+data PaymentCredentialTransaction = PaymentCredentialTransaction
+  { paymentCredentialTransactionTxHash         :: !TxHash
+  -- ^ Transaction hash.
+  , paymentCredentialTransactionSlot           :: !SlotNo
+  -- ^ Absolute slot of the block which contains the transaction.
+  , paymentCredentialTransactionInput          :: !Bool
+  -- ^ Payment credential controlled at least one of the consumed UTxOs.
+  , paymentCredentialTransactionOutput         :: !Bool
+  -- ^ Payment credential controlled at least one of the produced UTxOs.
+  , paymentCredentialTransactionRequiredSigner :: !Bool
+  -- ^ Payment credential was an additional required signer.
+  }
+  deriving stock (Show, Eq, Generic)
+  deriving (FromJSON, ToJSON)
+  via CustomJSON '[FieldLabelModifier '[StripPrefix "paymentCredentialTransaction", CamelToSnake]] PaymentCredentialTransaction
+
+-- | A paginated response over `PaymentCredentialTransaction`.
+data PaginatedPaymentCredentialTransaction = PaginatedPaymentCredentialTransaction
+  { paginatedPaymentCredentialTransactionData        :: ![PaymentCredentialTransaction]
+  -- ^ See `PaymentCredentialTransaction`.
+  , paginatedPaymentCredentialTransactionLastUpdated :: !LastUpdated
+  -- ^ See `LastUpdated`.
+  , paginatedPaymentCredentialTransactionNextCursor  :: !(Maybe NextCursor)
+  -- ^ See `NextCursor`.
+  }
+  deriving stock (Show, Eq, Generic)
+  deriving (FromJSON, ToJSON)
+  via CustomJSON '[FieldLabelModifier '[StripPrefix "paginatedPaymentCredentialTransaction", CamelToSnake]] PaginatedPaymentCredentialTransaction
+
+instance IsTimestamped PaginatedPaymentCredentialTransaction where
+  type TimestampedData PaginatedPaymentCredentialTransaction = [PaymentCredentialTransaction]
+  getTimestampedData = paginatedPaymentCredentialTransactionData
+  getTimestamp = paginatedPaymentCredentialTransactionLastUpdated
+
+instance HasCursor PaginatedPaymentCredentialTransaction where
+  getNextCursor = paginatedPaymentCredentialTransactionNextCursor

--- a/src/Maestro/Types/V1/Assets.hs
+++ b/src/Maestro/Types/V1/Assets.hs
@@ -1,0 +1,52 @@
+-- | Module to define types for /\"Assets\"/ category of endpoints defined at [docs.gomaestro.org](https://docs.gomaestro.org/Indexer-API/Assets/asset-addresses).
+module Maestro.Types.V1.Assets (
+  TokenRegistryMetadata (..),
+  AssetInfo (..),
+  TimestampedAssetInfo (..),
+) where
+
+import Data.Text (Text)
+import Data.Word (Word64)
+import Deriving.Aeson
+import Maestro.Types.V1.Common
+
+-- | Token registry metadata
+data TokenRegistryMetadata = TokenRegistryMetadata
+  { tokenRegistryMetadataName :: !Text
+  -- ^ Asset name.
+  , tokenRegistryMetadataDescription :: !Text
+  -- ^ Asset description.
+  , tokenRegistryMetadataDecimals :: !(Maybe Word64)
+  -- ^ Recommended value for decimal places.
+  , tokenRegistryMetadataLogo :: !(Maybe Text)
+  -- ^ Base64 encoded logo PNG associated with the asset.
+  , tokenRegistryMetadataUrl :: !(Maybe Text)
+  -- ^ URL associated with the asset.
+  , tokenRegistryMetadataTicker :: !(Maybe Text)
+  -- ^ Asset ticker.
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving (FromJSON, ToJSON) via CustomJSON '[FieldLabelModifier '[StripPrefix "tokenRegistryMetadata", CamelToSnake]] TokenRegistryMetadata
+
+-- | Information about a specific Cardano native-asset.
+data AssetInfo = AssetInfo
+  { assetInfoTokenRegistryMetadata :: !(Maybe TokenRegistryMetadata)
+  -- ^ See `TokenRegistryMetadata`.
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving (FromJSON, ToJSON) via CustomJSON '[FieldLabelModifier '[StripPrefix "assetInfo", CamelToSnake]] AssetInfo
+
+-- | Timestamped `AssetInfo` response.
+data TimestampedAssetInfo = TimestampedAssetInfo
+  { timestampedAssetInfoData :: !AssetInfo
+  -- ^ See `AssetInfo`.
+  , timestampedAssetInfoLastUpdated :: !LastUpdated
+  -- ^ See `LastUpdated`.
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving (FromJSON, ToJSON) via CustomJSON '[FieldLabelModifier '[StripPrefix "timestampedAssetInfo", CamelToSnake]] TimestampedAssetInfo
+
+instance IsTimestamped TimestampedAssetInfo where
+  type TimestampedData TimestampedAssetInfo = AssetInfo
+  getTimestampedData = timestampedAssetInfoData
+  getTimestamp = timestampedAssetInfoLastUpdated

--- a/src/Maestro/Types/V1/DefiMarkets.hs
+++ b/src/Maestro/Types/V1/DefiMarkets.hs
@@ -9,6 +9,7 @@ module Maestro.Types.V1.DefiMarkets (
 ) where
 
 import qualified Data.Text as T
+import Data.Time (UTCTime)
 import Deriving.Aeson
 import Maestro.Types.V1.Common
 import Servant.API
@@ -81,6 +82,7 @@ data OHLCCandleInfo = OHLCCandleInfo
   , ohlcCandleInfoCoinBOpen :: !Double
   , ohlcCandleInfoCoinBVolume :: !Double
   , ohlcCandleInfoCount :: !Integer
+  , ohlcCandleInfoTimestamp :: !UTCTime
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving

--- a/src/Maestro/Types/V1/DefiMarkets.hs
+++ b/src/Maestro/Types/V1/DefiMarkets.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE LambdaCase #-}
 
 -- | Module to define types for /"DeFi Markets"/ category of endpoints defined at [docs.gomaestro.org](https://docs.gomaestro.org/category/defi-market-api).
 module Maestro.Types.V1.DefiMarkets (
@@ -31,6 +32,12 @@ instance Show Dex where
 
 instance ToHttpApiData Dex where
   toQueryParam = T.pack . show
+
+instance FromHttpApiData Dex where
+  parseQueryParam = \case
+    "minswap" -> Right Minswap
+    "genius-yield" -> Right GeniusYield
+    _ -> Left "Invalid Dex"
 
 -- | Token Pair that is queried
 type PairOfDexTokens = "Token pair to look for. Format: XXX-YYY"

--- a/src/Maestro/Types/V1/DefiMarkets.hs
+++ b/src/Maestro/Types/V1/DefiMarkets.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
 -- | Module to define types for /"DeFi Markets"/ category of endpoints defined at [docs.gomaestro.org](https://docs.gomaestro.org/category/defi-market-api).
 module Maestro.Types.V1.DefiMarkets (
   Dex (..),
@@ -8,11 +10,14 @@ module Maestro.Types.V1.DefiMarkets (
   OHLCCandleInfo (..),
 ) where
 
+import Control.Arrow ((>>>))
+import Data.Data (Data (toConstr))
 import qualified Data.Text as T
 import Data.Time (UTCTime)
 import Deriving.Aeson
 import Maestro.Types.V1.Common
 import Servant.API
+import Type.Reflection (Typeable)
 
 -- | Denotes which dex to use
 data Dex = Minswap | GeniusYield
@@ -31,19 +36,13 @@ type PairOfDexTokens = "Token pair to look for. Format: XXX-YYY"
 
 -- | Time resolution for OHLC Candles
 data Resolution = Res1m | Res5m | Res15m | Res30m | Res1h | Res4h | Res1d | Res1w | Res1mo
-  deriving stock (Eq, Ord, Generic)
+  deriving stock (Eq, Ord, Generic, Data, Typeable, Enum, Bounded)
   deriving (FromJSON, ToJSON) via CustomJSON '[ConstructorTagModifier '[StripPrefix "Res"]] Resolution
 
+-- >>> show Res1mo
+-- "1mo"
 instance Show Resolution where
-  show Res1m = "1m"
-  show Res5m = "5m"
-  show Res15m = "15m"
-  show Res30m = "30m"
-  show Res1h = "1h"
-  show Res4h = "4h"
-  show Res1d = "1d"
-  show Res1w = "1w"
-  show Res1mo = "1mo"
+  show = toConstr >>> show >>> drop 3
 
 instance ToHttpApiData Resolution where
   toQueryParam = T.pack . show

--- a/src/Maestro/Types/V1/DefiMarkets.hs
+++ b/src/Maestro/Types/V1/DefiMarkets.hs
@@ -15,6 +15,7 @@ import Data.Data (Data (toConstr))
 import qualified Data.Text as T
 import Data.Time (UTCTime)
 import Deriving.Aeson
+import GHC.Natural (Natural)
 import Maestro.Types.V1.Common
 import Servant.API
 import Type.Reflection (Typeable)
@@ -80,7 +81,7 @@ data OHLCCandleInfo = OHLCCandleInfo
   , ohlcCandleInfoCoinBLow :: !Double
   , ohlcCandleInfoCoinBOpen :: !Double
   , ohlcCandleInfoCoinBVolume :: !Double
-  , ohlcCandleInfoCount :: !Integer
+  , ohlcCandleInfoCount :: !Natural
   , ohlcCandleInfoTimestamp :: !UTCTime
   }
   deriving stock (Show, Eq, Ord, Generic)

--- a/src/Maestro/Types/V1/DefiMarkets.hs
+++ b/src/Maestro/Types/V1/DefiMarkets.hs
@@ -23,7 +23,7 @@ import Type.Reflection (Typeable)
 
 -- | Denotes which dex to use
 data Dex = Minswap | GeniusYield
-  deriving stock (Eq, Ord, Generic)
+  deriving stock (Eq, Ord, Generic, Enum, Bounded)
   deriving (FromJSON, ToJSON) via CustomJSON '[ConstructorTagModifier '[CamelToKebab]] Dex
 
 instance Show Dex where

--- a/src/Maestro/Types/V1/DefiMarkets.hs
+++ b/src/Maestro/Types/V1/DefiMarkets.hs
@@ -55,6 +55,20 @@ instance Show Resolution where
 instance ToHttpApiData Resolution where
   toQueryParam = T.pack . show
 
+instance FromHttpApiData Resolution where
+  -- Could have used `find` in combination with `[minBound..maxBound]` to make it more versatile.
+  parseQueryParam = \case
+    "1m" -> Right Res1m
+    "5m" -> Right Res5m
+    "15m" -> Right Res15m
+    "30m" -> Right Res30m
+    "1h" -> Right Res1h
+    "4h" -> Right Res4h
+    "1d" -> Right Res1d
+    "1w" -> Right Res1w
+    "1mo" -> Right Res1mo
+    _ -> Left "Invalid Resolution"
+
 data DexPairInfo = DexPairInfo
   { dexPairInfoCoinAAssetName :: !TokenName
   , dexPairInfoCoinAPolicy :: !PolicyId


### PR DESCRIPTION
This PR adds,

* [x] GET `/addresses/:address/transactions`
* [x] `asset` query parameter to GET `/addresses/cred/:credential/utxos`
* [x] POST `/addresses/cred/utxos` 
* [x] GET `/addresses/cred/:credential/transactions`
* [x] GET `/assets/:asset`
* [x] `from`, `to`, `limit` query parameters to GET `/markets/dexs/ohlc/:dex/:pair`
* [x] provision to prevent api-key from being leaked in error messages
* [x] provision to handle Maestro error bodies which are not enclosed in double quotes. Earlier behaviour was to expect message such as `"Failed to deserialise"` and not `Failed to deserialise`.
* [x] `FromHttpApiData`, `ToHttpApiData` instance for `SlotNo`
* [x] `Eq`, `Ord`, `Enum`, `Bounded`, `ToJSON`, `FromHttpApiData` instance for `Order`
* [x] `Enum`, `Bounded`, `FromHttpApiData` instance for `Dex`
* [x] `Data`, `Typeable`, `Enum`, `Bounded`, `FromHttpApiData` instance for `Resolution` and also refactored it's `Show` instance.