### PR TITLE
chore: upgrade GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -10,6 +10,9 @@ on:
 permissions:
     contents: read
 
+env:
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
     build:
         runs-on: ubuntu-22.04
@@ -51,7 +54,7 @@ jobs:
                       xz-utils \
                       zlib1g-dev
             - name: Setup haskell tooling
-              uses: haskell/actions/setup@v2
+              uses: haskell-actions/setup@v2
               with:
                   ghc-version: "8.10.7"
                   cabal-version: "3.8"
@@ -103,7 +106,7 @@ jobs:
             - name: Generate documentation (cabal haddock)
               run: cabal haddock --html --hyperlink-source --haddock-options="--use-unicode"
             - name: Upload haddock documentation
-              uses: actions/upload-pages-artifact@v3
+              uses: actions/upload-pages-artifact@v4
               with:
                   path: ./dist-newstyle/build/x86_64-linux/ghc-8.10.7/${{env.MAESTRO_SDK_VERSION}}/doc/html/maestro-sdk/
             - name: Upload artifacts

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -105,10 +105,14 @@ jobs:
                   echo "MAESTRO_SDK_VERSION=${MAESTRO_SDK_VERSION}" >> $GITHUB_OUTPUT
             - name: Generate documentation (cabal haddock)
               run: cabal haddock --html --hyperlink-source --haddock-options="--use-unicode"
+            - name: Package haddock documentation
+              run: |
+                  tar -C ./dist-newstyle/build/x86_64-linux/ghc-8.10.7/${{ env.MAESTRO_SDK_VERSION }}/doc/html/maestro-sdk -cf "$RUNNER_TEMP/artifact.tar" .
             - name: Upload haddock documentation
-              uses: actions/upload-pages-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
-                  path: ./dist-newstyle/build/x86_64-linux/ghc-8.10.7/${{env.MAESTRO_SDK_VERSION}}/doc/html/maestro-sdk/
+                  name: github-pages
+                  path: ${{ runner.temp }}/artifact.tar
             - name: Upload artifacts
               uses: actions/upload-artifact@v7
               with:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -18,7 +18,7 @@ jobs:
             MAESTRO_SDK_VERSION: ${{ steps.get_maestro_sdk_version.outputs.MAESTRO_SDK_VERSION }}
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v6
             - name: Install dependencies (apt-get)
               run: |
                   sudo apt-get update
@@ -58,7 +58,7 @@ jobs:
                   enable-stack: true
                   stack-version: "2.9"
             - name: Setup cache
-              uses: actions/cache@v3
+              uses: actions/cache@v5
               env:
                   cache-name: cache-cabal
               with:
@@ -107,7 +107,7 @@ jobs:
               with:
                   path: ./dist-newstyle/build/x86_64-linux/ghc-8.10.7/${{env.MAESTRO_SDK_VERSION}}/doc/html/maestro-sdk/
             - name: Upload artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: source-distribution-file
                   path: ./dist-newstyle/sdist/${{env.MAESTRO_SDK_VERSION}}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
         needs: build
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
-            - uses: actions/download-artifact@v4
+              uses: actions/checkout@v6
+            - uses: actions/download-artifact@v8
               name: Download source distribution file artifact
               with:
                   name: source-distribution-file
                   path: ./artifacts
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v8
               name: Download haddock artifact
               with:
                   name: github-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 permissions:
     contents: write
 
+env:
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
     build:
         uses: ./.github/workflows/haskell.yml
@@ -53,7 +56,7 @@ jobs:
                     "./artifacts/${HADDOCK_FILE}#Haddock (tar)"
                   echo "::notice::Succesfully created release draft ${SEMANTIC_VERSION} from ${GIT_REVISION}. (Uploaded: ${{ env.MAESTRO_SDK_VERSION }}.tar.gz)"
             - name: Setup haskell tooling
-              uses: haskell/actions/setup@v2
+              uses: haskell-actions/setup@v2
               with:
                   ghc-version: "8.10.7"
                   cabal-version: "3.8"


### PR DESCRIPTION
This updates GitHub Actions references to current Node 24-compatible releases where upstream support is available.

Automated by Codex after an org-wide workflow audit.